### PR TITLE
feat: add top component ui for setgoal screen

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -139,6 +139,8 @@ complexity:
     ignoreDefaultParameters: false
     ignoreDataClasses: true
     ignoreAnnotatedParameter: []
+    ignoreAnnotated:
+      - 'Composable'
   MethodOverloading:
     active: false
     threshold: 6

--- a/core/designsystem/src/main/java/com/zachnr/bookplayfree/designsystem/icons/BpfIcons.kt
+++ b/core/designsystem/src/main/java/com/zachnr/bookplayfree/designsystem/icons/BpfIcons.kt
@@ -10,4 +10,6 @@ object BpfIcons {
     val settingFilled = R.drawable.ic_setting_filled
     val settingOutlined = R.drawable.ic_setting_outlined
     val warning = R.drawable.ic_warning
+    val chevronWhiteLeft = R.drawable.ic_chevron_white_left
+    val helpWhite = R.drawable.ic_help_white
 }

--- a/core/designsystem/src/main/java/com/zachnr/bookplayfree/designsystem/theme/Colors.kt
+++ b/core/designsystem/src/main/java/com/zachnr/bookplayfree/designsystem/theme/Colors.kt
@@ -5,6 +5,8 @@ import androidx.compose.ui.graphics.Color
 
 /**
  * Book Play Free colors.
+ *
+ * Refer hex transparency here: https://gist.github.com/lopspower/03fb1cc0ac9f32ef38f4
  */
 val Purple80 = Color(0xFFD0BCFF)
 val PurpleGrey80 = Color(0xFFCCC2DC)
@@ -29,3 +31,5 @@ val GreenForest = Color(0xFF388E3C)
 val CheckboxUncheckedGray = Color(0xFFBDBDBD)
 val CheckboxDisabledLightGray = Color(0xFFE0E0E0)
 val CheckboxDisabledUncheckedBorder = Color(0x61000000)
+
+val BlackOpacity33 = Color(0x54000000)

--- a/core/designsystem/src/main/res/drawable/ic_chevron_white_left.xml
+++ b/core/designsystem/src/main/res/drawable/ic_chevron_white_left.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M14,7L9,12L14,17"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="round"/>
+</vector>

--- a/core/designsystem/src/main/res/drawable/ic_help_white.xml
+++ b/core/designsystem/src/main/res/drawable/ic_help_white.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M7.5,7.688C7.5,7.688 7.568,6.141 9.072,4.9C9.966,4.164 11.039,3.951 12,3.938C12.878,3.927 13.663,4.075 14.132,4.304C14.934,4.697 16.5,5.653 16.5,7.688C16.5,9.828 15.132,10.799 13.577,11.868C12.023,12.937 11.625,13.986 11.625,15.188"
+      android:strokeWidth="1.25"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M11.625,20.25C12.453,20.25 13.125,19.578 13.125,18.75C13.125,17.921 12.453,17.25 11.625,17.25C10.797,17.25 10.125,17.921 10.125,18.75C10.125,19.578 10.797,20.25 11.625,20.25Z"
+      android:fillColor="#ffffff"/>
+</vector>

--- a/core/navigation/src/main/java/com/zachnr/bookplayfree/navigation/impl/NavigatorImpl.kt
+++ b/core/navigation/src/main/java/com/zachnr/bookplayfree/navigation/impl/NavigatorImpl.kt
@@ -8,7 +8,9 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.receiveAsFlow
 
 /**
- * A global navigation that starts from pre-login graph
+ * A global navigation that starts from pre-login graph.
+ *
+ * The execution of this navigation is in [AppNavigation]
  */
 internal class NavigatorImpl(
     override val startDestination: Destination

--- a/core/uicomponent/src/main/java/com/zachnr/bookplayfree/uicomponent/base/BaseViewModel.kt
+++ b/core/uicomponent/src/main/java/com/zachnr/bookplayfree/uicomponent/base/BaseViewModel.kt
@@ -64,6 +64,13 @@ abstract class BaseViewModel<State : ViewState, Event : ViewEvent, Effect : View
     }
 
     /**
+     * Navigates up in the navigation stack.
+     */
+    fun navigateUp() = viewModelScope.launch(Dispatchers.Main) {
+        navigator.navigateUp()
+    }
+
+    /**
      * Update UI states with corresponding effects action.
      *
      * @param updates Logic operation that manage how to update the new state.

--- a/core/uicomponent/src/main/java/com/zachnr/bookplayfree/uicomponent/helpbubble/BubbleTextTailRight.kt
+++ b/core/uicomponent/src/main/java/com/zachnr/bookplayfree/uicomponent/helpbubble/BubbleTextTailRight.kt
@@ -1,0 +1,90 @@
+package com.zachnr.bookplayfree.uicomponent.helpbubble
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.constraintlayout.compose.ConstraintLayout
+import com.zachnr.bookplayfree.designsystem.theme.BlackOpacity33
+import com.zachnr.bookplayfree.uicomponent.R
+import com.zachnr.bookplayfree.uicomponent.helpbubble.BubbleTextTailRightConst.TAIL_TRANSPARENCY
+
+/**
+ * A composable function that displays a text bubble with a tail on the right side.
+ * This is typically used for help or informational messages.
+ *
+ * @param modifier Optional [Modifier] for this composable.
+ * @param text The text string to be displayed inside the bubble.
+ * @param onClick A lambda function to be executed when the bubble is clicked.
+ *                Defaults to an empty lambda.
+ */
+@Composable
+fun BubbleTextTailRight(
+    modifier: Modifier = Modifier,
+    text: String,
+    onClick: () -> Unit = {}
+) {
+    Row(
+        modifier = modifier.clickable(
+            interactionSource = remember { MutableInteractionSource() },
+            indication = null,
+            onClick = { onClick() }
+        ),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        ConstraintLayout(
+            modifier = Modifier
+                .height(32.dp)
+                .background(
+                    color = BlackOpacity33,
+                    shape = RoundedCornerShape(8.dp)
+                )
+        ) {
+            val textContainer = createRef()
+            Text(
+                text = text,
+                style = MaterialTheme.typography.bodyMedium,
+                color = Color.White,
+                modifier = Modifier
+                    .padding(horizontal = 18.dp)
+                    .constrainAs(textContainer) {
+                        top.linkTo(parent.top)
+                        bottom.linkTo(parent.bottom)
+                        start.linkTo(parent.start)
+                        end.linkTo(parent.end)
+                    }
+            )
+        }
+        Image(
+            painter = painterResource(id = R.drawable.bg_tail_black),
+            contentDescription = null,
+            modifier = Modifier.alpha(TAIL_TRANSPARENCY)
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun HelpBubblePreview() {
+    BubbleTextTailRight(text = "Need help ?")
+}
+
+private object BubbleTextTailRightConst {
+    const val TAIL_TRANSPARENCY = 0.33f
+}
+

--- a/core/uicomponent/src/main/java/com/zachnr/bookplayfree/uicomponent/helpbubble/BubbleTextTailRight.kt
+++ b/core/uicomponent/src/main/java/com/zachnr/bookplayfree/uicomponent/helpbubble/BubbleTextTailRight.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -47,27 +48,20 @@ fun BubbleTextTailRight(
         ),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        ConstraintLayout(
+        Box(
             modifier = Modifier
                 .height(32.dp)
                 .background(
                     color = BlackOpacity33,
                     shape = RoundedCornerShape(8.dp)
                 )
+                .padding(horizontal = 18.dp),
+            contentAlignment = Alignment.Center
         ) {
-            val textContainer = createRef()
             Text(
                 text = text,
                 style = MaterialTheme.typography.bodyMedium,
-                color = Color.White,
-                modifier = Modifier
-                    .padding(horizontal = 18.dp)
-                    .constrainAs(textContainer) {
-                        top.linkTo(parent.top)
-                        bottom.linkTo(parent.bottom)
-                        start.linkTo(parent.start)
-                        end.linkTo(parent.end)
-                    }
+                color = Color.White
             )
         }
         Image(

--- a/core/uicomponent/src/main/java/com/zachnr/bookplayfree/uicomponent/icons/CircularIconButton.kt
+++ b/core/uicomponent/src/main/java/com/zachnr/bookplayfree/uicomponent/icons/CircularIconButton.kt
@@ -1,0 +1,69 @@
+package com.zachnr.bookplayfree.uicomponent.icons
+
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.zachnr.bookplayfree.designsystem.icons.BpfIcons
+import com.zachnr.bookplayfree.designsystem.theme.BlackOpacity33
+import com.zachnr.bookplayfree.uicomponent.icons.CircularIconButtonConst.SCALE_ICON
+
+/**
+ * A circular icon button composable with background black opacity 33%.
+ *
+ * @param modifier The modifier to be applied to the button.
+ * @param onClick The callback to be invoked when the button is clicked.
+ * @param iconId The resource ID of the icon to be displayed. Defaults to [BpfIcons.chevronWhiteLeft].
+ * @param size The size of the button in dp. Defaults to 32.
+ * The icon size will be 60% of this value.
+ */
+@Composable
+fun CircularIconButton(
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit = {},
+    @DrawableRes iconId: Int = BpfIcons.chevronWhiteLeft,
+    size: Int = 32
+) {
+    Box(
+        modifier = modifier
+            .size(size.dp)
+            .background(
+                color = BlackOpacity33,
+                shape = CircleShape
+            ).clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+                onClick = { onClick() }
+            ),
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            painter = painterResource(id = iconId),
+            contentDescription = null,
+            modifier = Modifier.size((size * SCALE_ICON).dp),
+            tint = Color.Unspecified
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CircularIconButtonPreview() {
+    CircularIconButton()
+}
+
+private object CircularIconButtonConst {
+    const val SCALE_ICON = 0.33f
+}

--- a/core/uicomponent/src/main/java/com/zachnr/bookplayfree/uicomponent/icons/CircularIconButton.kt
+++ b/core/uicomponent/src/main/java/com/zachnr/bookplayfree/uicomponent/icons/CircularIconButton.kt
@@ -65,5 +65,5 @@ private fun CircularIconButtonPreview() {
 }
 
 private object CircularIconButtonConst {
-    const val SCALE_ICON = 0.33f
+    const val SCALE_ICON = 0.6f
 }

--- a/core/uicomponent/src/main/res/drawable/bg_tail_black.xml
+++ b/core/uicomponent/src/main/res/drawable/bg_tail_black.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="10dp"
+    android:height="20dp"
+    android:viewportWidth="10"
+    android:viewportHeight="20">
+  <path
+      android:pathData="M10,10C10,10 0,12.222 -0,20L0,-0C0,7.778 10,10 10,10Z"
+      android:fillColor="#000000"/>
+</vector>

--- a/core/uicomponent/src/main/res/values-in/strings.xml
+++ b/core/uicomponent/src/main/res/values-in/strings.xml
@@ -12,4 +12,5 @@
     <string name="setting_shake_to_next">Goyangkan perangkat untuk ke halaman berikutnya</string>
     <string name="search">Cari</string>
     <string name="setting_search">Cari pengaturan</string>
+    <string name="set_goal_need_help">Butuh bantuan?</string>
 </resources>

--- a/core/uicomponent/src/main/res/values/strings.xml
+++ b/core/uicomponent/src/main/res/values/strings.xml
@@ -12,4 +12,5 @@
     <string name="setting_shake_to_next">Shake device to next the page</string>
     <string name="search">Search</string>
     <string name="setting_search">Search setting</string>
+    <string name="set_goal_need_help">Need help?</string>
 </resources>

--- a/feature/dashboard/src/main/java/com/zachnr/bookplayfree/dashboard/presentation/pages/setting/SettingScreen.kt
+++ b/feature/dashboard/src/main/java/com/zachnr/bookplayfree/dashboard/presentation/pages/setting/SettingScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.zachnr.bookplayfree.dashboard.presentation.pages.setting.model.SettingEvent
 import com.zachnr.bookplayfree.dashboard.presentation.pages.setting.model.SettingOrderingGroupUI
 import com.zachnr.bookplayfree.dashboard.presentation.pages.setting.model.SettingOrderingItemUI
 import com.zachnr.bookplayfree.dashboard.presentation.pages.setting.model.SettingOrderingState
@@ -49,6 +50,7 @@ internal fun SettingScreen(
     SettingScreen(
         state = state,
         modifier = modifier,
+        navigationEvent = viewModel::sendEvent,
         setIsReadBookWhenLaunch = viewModel::setIsReadBookWhenLaunch,
         setIsShakeToNext = viewModel::setIsShakeToNext,
         setIsEffect3D = viewModel::setIsEffect3d
@@ -59,6 +61,7 @@ internal fun SettingScreen(
 internal fun SettingScreen(
     modifier: Modifier = Modifier,
     state: SettingState,
+    navigationEvent: (SettingEvent) -> Unit = {},
     setIsReadBookWhenLaunch: (Boolean) -> Unit = {},
     setIsShakeToNext: (Boolean) -> Unit = {},
     setIsEffect3D: (Boolean) -> Unit = {},
@@ -102,11 +105,19 @@ internal fun SettingScreen(
                         items(items = group.menus) { item ->
                             when (item.itemId) {
                                 // TODO: Separate the action no dedicated action
-                                SettingMenu.FILE_SYNC,
-                                SettingMenu.SET_GOALS -> {
+                                SettingMenu.FILE_SYNC -> {
                                     SettingItemOrderingBasic(
                                         modifier = Modifier.padding(horizontal = 14.dp),
                                         data = item
+                                    )
+                                }
+                                SettingMenu.SET_GOALS -> {
+                                    SettingItemOrderingBasic(
+                                        modifier = Modifier.padding(horizontal = 14.dp),
+                                        data = item,
+                                        onClick = {
+                                            navigationEvent(SettingEvent.OnSetGoalMenuClicked)
+                                        }
                                     )
                                 }
 

--- a/feature/dashboard/src/main/java/com/zachnr/bookplayfree/dashboard/presentation/pages/setting/SettingViewModel.kt
+++ b/feature/dashboard/src/main/java/com/zachnr/bookplayfree/dashboard/presentation/pages/setting/SettingViewModel.kt
@@ -3,14 +3,15 @@ package com.zachnr.bookplayfree.dashboard.presentation.pages.setting
 import android.util.Log
 import androidx.lifecycle.viewModelScope
 import com.zachnr.bookplayfree.dashboard.presentation.pages.setting.mapper.SettingMapper
+import com.zachnr.bookplayfree.dashboard.presentation.pages.setting.model.SettingEvent
 import com.zachnr.bookplayfree.dashboard.presentation.pages.setting.model.SettingOrderingState
 import com.zachnr.bookplayfree.dashboard.presentation.pages.setting.model.SettingState
 import com.zachnr.bookplayfree.domain.model.setting.SettingOrderingDomain
 import com.zachnr.bookplayfree.domain.repository.setting.SettingRepository
 import com.zachnr.bookplayfree.navigation.interfaces.Navigator
+import com.zachnr.bookplayfree.navigation.route.Destination
 import com.zachnr.bookplayfree.uicomponent.base.BaseViewModel
 import com.zachnr.bookplayfree.uicomponent.base.ViewEffect
-import com.zachnr.bookplayfree.uicomponent.base.ViewEvent
 import com.zachnr.bookplayfree.utils.utils.DispatcherProvider
 import com.zachnr.bookplayfree.utils.utils.FlowConst.DEFAULT_STOP_TIMEOUT
 import kotlinx.coroutines.flow.SharingStarted
@@ -26,7 +27,7 @@ class SettingViewModel(
     private val dispatcher: DispatcherProvider,
     private val settingRepository: SettingRepository,
     private val settingMapper: SettingMapper
-) : BaseViewModel<SettingState, ViewEvent, ViewEffect>(navigator) {
+) : BaseViewModel<SettingState, SettingEvent, ViewEffect>(navigator) {
 
     private val settingDomain: StateFlow<List<SettingOrderingDomain>> =
         settingRepository.settingData.stateIn(
@@ -37,6 +38,12 @@ class SettingViewModel(
 
     init {
         observeSettingData()
+    }
+
+    override fun handleEvents(event: SettingEvent) {
+        when (event) {
+            is SettingEvent.OnSetGoalMenuClicked -> navigate(Destination.SetGoalScreen)
+        }
     }
 
     override fun setInitialState(): SettingState = SettingState()

--- a/feature/dashboard/src/main/java/com/zachnr/bookplayfree/dashboard/presentation/pages/setting/model/SettingEvent.kt
+++ b/feature/dashboard/src/main/java/com/zachnr/bookplayfree/dashboard/presentation/pages/setting/model/SettingEvent.kt
@@ -1,0 +1,7 @@
+package com.zachnr.bookplayfree.dashboard.presentation.pages.setting.model
+
+import com.zachnr.bookplayfree.uicomponent.base.ViewEvent
+
+interface SettingEvent : ViewEvent {
+    data object OnSetGoalMenuClicked : SettingEvent
+}

--- a/feature/setgoal/src/main/java/com/zachnr/bookplayfree/setgoal/model/SetGoalScreenEvent.kt
+++ b/feature/setgoal/src/main/java/com/zachnr/bookplayfree/setgoal/model/SetGoalScreenEvent.kt
@@ -1,0 +1,7 @@
+package com.zachnr.bookplayfree.setgoal.model
+
+import com.zachnr.bookplayfree.uicomponent.base.ViewEvent
+
+interface SetGoalScreenEvent : ViewEvent {
+    data object OnBackClicked : SetGoalScreenEvent
+}

--- a/feature/setgoal/src/main/java/com/zachnr/bookplayfree/setgoal/model/SetGoalState.kt
+++ b/feature/setgoal/src/main/java/com/zachnr/bookplayfree/setgoal/model/SetGoalState.kt
@@ -1,20 +1,17 @@
 package com.zachnr.bookplayfree.setgoal.model
 
+import androidx.annotation.DrawableRes
+import androidx.compose.ui.graphics.Color
+import com.zachnr.bookplayfree.designsystem.theme.GreenForest
 import com.zachnr.bookplayfree.uicomponent.base.ViewState
 
 internal interface SetGoalState : ViewState {
     data object Initial : SetGoalState
     data class Success(
-        val goals: List<GoalItem> = emptyList()
+        val title: String = "",
+        val isActive: Boolean = false,
+        val target: Int = 0,
+        val targetText: String = "",
+        @DrawableRes val colorTheme: Color = GreenForest
     ) : SetGoalState
-}
-
-internal data class GoalItem(
-    val type: CardType,
-    val isActive: Boolean = false,
-    val target: Int = 0,
-)
-
-internal enum class CardType {
-    PAGE, BOOK, MINUTES
 }

--- a/feature/setgoal/src/main/java/com/zachnr/bookplayfree/setgoal/presentation/SetGoalScreen.kt
+++ b/feature/setgoal/src/main/java/com/zachnr/bookplayfree/setgoal/presentation/SetGoalScreen.kt
@@ -1,14 +1,21 @@
 package com.zachnr.bookplayfree.setgoal.presentation
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.zachnr.bookplayfree.setgoal.model.CardType
-import com.zachnr.bookplayfree.setgoal.model.GoalItem
+import com.zachnr.bookplayfree.designsystem.icons.BpfIcons
+import com.zachnr.bookplayfree.designsystem.theme.GreenForest
+import com.zachnr.bookplayfree.setgoal.model.SetGoalScreenEvent
 import com.zachnr.bookplayfree.setgoal.model.SetGoalState
+import com.zachnr.bookplayfree.uicomponent.R
+import com.zachnr.bookplayfree.uicomponent.helpbubble.BubbleTextTailRight
+import com.zachnr.bookplayfree.uicomponent.icons.CircularIconButton
 import org.koin.androidx.compose.koinViewModel
 
 @Composable
@@ -27,26 +34,55 @@ internal fun SetGoalScreen(
 internal fun SetGoalScreen(
     modifier: Modifier = Modifier,
     state: SetGoalState,
+    navigationEvent: (SetGoalScreenEvent) -> Unit = {}
 ) {
-    ConstraintLayout(
-        modifier = modifier.fillMaxSize()
-    ) {
-        // TODO: To be implemented
-        state
+    when (state) {
+        is SetGoalState.Success -> {
+            ConstraintLayout(
+                modifier = modifier
+                    .background(state.colorTheme)
+                    .fillMaxSize()
+            ) {
+                val (imgSetGoalBack, bubbleSetGoalBubble, imgSetGoalQuestion) = createRefs()
+                CircularIconButton(
+                    modifier = Modifier.constrainAs(imgSetGoalBack) {
+                        top.linkTo(parent.top, margin = 42.dp)
+                        start.linkTo(parent.start, margin = 14.dp)
+                    },
+                    iconId = BpfIcons.chevronWhiteLeft,
+                    onClick = { navigationEvent(SetGoalScreenEvent.OnBackClicked) }
+                )
+                BubbleTextTailRight(
+                    modifier = Modifier.constrainAs(bubbleSetGoalBubble) {
+                        top.linkTo(imgSetGoalQuestion.top)
+                        bottom.linkTo(imgSetGoalQuestion.bottom)
+                        end.linkTo(imgSetGoalQuestion.start, margin = 8.dp)
+                    },
+                    text = stringResource(R.string.set_goal_need_help)
+                )
+                CircularIconButton(
+                    modifier = Modifier.constrainAs(imgSetGoalQuestion) {
+                        top.linkTo(parent.top, margin = 42.dp)
+                        end.linkTo(parent.end, margin = 14.dp)
+                    },
+                    iconId = BpfIcons.helpWhite
+                )
+            }
+        }
+        else -> Unit
     }
 }
 
 @Preview(showBackground = true)
 @Composable
 private fun SetGoalScreenPreview() {
-    val previewState = GoalItem(
-        type = CardType.PAGE,
-        isActive = false,
-        target = 2
-    )
     SetGoalScreen(
         state = SetGoalState.Success(
-            goals = listOf(previewState)
+            isActive = false,
+            target = 2,
+            title = "How many pages will you read daily?",
+            targetText = "Pages",
+            colorTheme = GreenForest,
         )
     )
 }

--- a/feature/setgoal/src/main/java/com/zachnr/bookplayfree/setgoal/presentation/SetGoalViewModel.kt
+++ b/feature/setgoal/src/main/java/com/zachnr/bookplayfree/setgoal/presentation/SetGoalViewModel.kt
@@ -1,14 +1,20 @@
 package com.zachnr.bookplayfree.setgoal.presentation
 
 import com.zachnr.bookplayfree.navigation.interfaces.Navigator
+import com.zachnr.bookplayfree.setgoal.model.SetGoalScreenEvent
 import com.zachnr.bookplayfree.setgoal.model.SetGoalState
 import com.zachnr.bookplayfree.uicomponent.base.BaseViewModel
 import com.zachnr.bookplayfree.uicomponent.base.ViewEffect
-import com.zachnr.bookplayfree.uicomponent.base.ViewEvent
 
 internal class SetGoalViewModel(
     navigator: Navigator
-) : BaseViewModel<SetGoalState, ViewEvent, ViewEffect>(navigator) {
+) : BaseViewModel<SetGoalState, SetGoalScreenEvent, ViewEffect>(navigator) {
 
     override fun setInitialState() = SetGoalState.Initial
+
+    override fun handleEvents(event: SetGoalScreenEvent) {
+        when (event) {
+            SetGoalScreenEvent.OnBackClicked -> navigateUp()
+        }
+    }
 }


### PR DESCRIPTION
5% progress
figma:
<img width="340" height="723" alt="image" src="https://github.com/user-attachments/assets/95e919f5-0c09-4f37-b10d-d0265a242f9b" />
<img width="422" height="896" alt="image" src="https://github.com/user-attachments/assets/30fc544c-466c-46c3-a421-3c96e9e5c9a9" />


/gemini-review 